### PR TITLE
RichTextEditor props now has a property to set the editor to readOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uno-react-draftjs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Rich text editor",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -11,7 +11,7 @@ export type RichTextEditorRef = {
 };
 
 export const UnoReactDraftjs = forwardRef<RichTextEditorRef, RichTextEditorProps>(
-    ({ markdown, setMark, placeholder }: RichTextEditorProps, ref) => {
+    ({ markdown, setMark, placeholder, readonly }: RichTextEditorProps, ref) => {
         const [editorState, setEditor] = useState(_convertFromMark(markdown));
         const [hidden, setHidden] = React.useState(true);
         const editor = useRef<Editor>(null);
@@ -96,6 +96,7 @@ export const UnoReactDraftjs = forwardRef<RichTextEditorRef, RichTextEditorProps
                     editorState={editorState}
                     onChange={setEditor}
                     placeholder={placeholder}
+                    readOnly={readonly}
                 />
             </div>
         );

--- a/src/interfaces/RichTexEditorProps.ts
+++ b/src/interfaces/RichTexEditorProps.ts
@@ -3,4 +3,5 @@ export interface RichTextEditorProps {
     setMark: any;
     placeholder: string;
     ref?: any;
+    readonly?: boolean;
 }


### PR DESCRIPTION
RichTextEditor props now has a property to set the editor to readOnly.